### PR TITLE
Ensure immediate delivery of password reset emails

### DIFF
--- a/colavo/lib/auth.ts
+++ b/colavo/lib/auth.ts
@@ -95,11 +95,12 @@ export const auth = betterAuth({
           expirationHours: 1, // Reset tokens expire in 1 hour
         });
 
-        // Send email using ResendEmailService
+        // Send email using ResendEmailService (immediate delivery)
         await ResendEmailService.sendEmail({
           to: [user.email],
           subject: "Reset your Collavo password",
           html: emailHtml,
+          // Explicitly omit scheduledAt to ensure immediate delivery
         });
 
         // Log success in development


### PR DESCRIPTION
Updated the call to ResendEmailService.sendEmail to explicitly omit the scheduledAt parameter, ensuring that password reset emails are sent immediately.